### PR TITLE
Skip blank lines and comment lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 > This project follows the [semver](http://semver.org) pro forma and uses the [git-flow branching model](https://nvie.com/posts/a-successful-git-branching-model/ "original blog post").
 
 ## Description
-BED provides I/O and utilities for the BED file format.
+BED provides I/O and utilities for the [BED file format](https://samtools.github.io/hts-specs/BEDv1.pdf).
+
 
 ## Installation
 You can install the BED package from the [Julia REPL](https://docs.julialang.org/en/v1/manual/getting-started/).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,7 +9,7 @@
 > This project follows the [semver](http://semver.org) pro forma and uses the [git-flow branching model](https://nvie.com/posts/a-successful-git-branching-model/ "original blog post").
 
 ## Description
-BED provides I/O and utilities for the BED file format.
+BED provides I/O and utilities for the [BED file format](https://samtools.github.io/hts-specs/BEDv1.pdf).
 
 ## Installation
 You can install the BED package from the [Julia REPL](https://docs.julialang.org/en/v1/manual/getting-started/).

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -85,6 +85,7 @@ function GenomicFeatures.eachoverlap(reader::Reader, interval::GenomicFeatures.I
 end
 
 const record_machine, file_machine = (function ()
+    alt = Automa.RegExp.alt
     cat = Automa.RegExp.cat
     rep = Automa.RegExp.rep
     opt = Automa.RegExp.opt
@@ -167,6 +168,12 @@ const record_machine, file_machine = (function ()
     record.actions[:enter] = [:mark]
     record.actions[:exit] = [:record]
 
+    hspace = re"[ \t\v]"
+
+    blankline = rep(hspace)
+
+    comment = re"#.*"
+
     newline = let
         lf = re"\n"
         lf.actions[:enter] = [:countline]
@@ -174,7 +181,11 @@ const record_machine, file_machine = (function ()
         cat(opt('\r'), lf)
     end
 
-    file = rep(cat(record, newline))
+    file = rep(alt(
+        cat(record, newline),
+        cat(blankline, newline),
+        cat(comment, newline),
+    ))
 
     return map(Automa.compile, (record, file))
 end)()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,6 +148,71 @@ end
         @test_throws Exception check_bed_parse(filepath)
     end
 
+    # https://github.com/BioJulia/BED.jl/issues/13
+    str = """
+
+    # comment
+    test1\t1\t9
+
+
+    test2\t1\t9
+    test3\t1\t9
+        \t \t
+    # comment
+    # comment
+    test4\t1\t9
+
+    """
+
+    @test collect(BED.Reader(IOBuffer(str))) == BED.Record.(string.("test", 1:4, "\t1\t9"))
+
+    str = """
+    # HOMER Peaks
+    # Peak finding parameters:
+    # tag directory = GM_tagdir
+    #
+    # total peaks = 158781
+    # peak size = 153
+    # peaks found using tags on both strands
+    # minimum distance between peaks = 306
+    # fragment length = 152
+    # genome size = 2000000000
+    # Total tags = 322230773.0
+    # Total tags in peaks = 93989466.0
+    # Approximate IP efficiency = 29.17%
+    # tags per bp = 0.114786
+    # expected tags per peak = 17.562
+    # maximum tags considered per bp = 16.0
+    # effective number of tags used for normalization = 10000000.0
+    # Peaks have been centered at maximum tag pile-up
+    # FDR rate threshold = 0.001000000
+    # FDR effective poisson threshold = 1.591138e-05
+    # FDR tag threshold = 38.0
+    # number of putative peaks = 682969
+    #
+    # size of region used for local filtering = 10000
+    # Fold over local region required = 4.00
+    # Poisson p-value over local region required = 1.00e-04
+    # Putative peaks filtered by local signal = 523066
+    #
+    # Maximum fold under expected unique positions for tags = 2.00
+    # Putative peaks filtered for being too clonal = 1122
+    #
+    # cmd = findPeaks GM_tagdir -style factor -o GM.peaks.txt
+    #
+    # Column Headers:
+    #PeakID\tchr\tstart\tend\tstrand\tNormalized Tag Count\tfocus ratio\tfindPeaks Score\tFold Change vs Local\tp-value vs Local\tClonal Fold Change
+    chr21\t8401346\t8401499\tchr21-3\t1\t+
+    chr21\t8445578\t8445731\tchr21-1\t1\t+
+    chr21\t8218308\t8218461\tchr21-2\t1\t+
+    """
+
+    @test collect(BED.Reader(IOBuffer(str))) == [
+        BED.Record("chr21\t8401346\t8401499\tchr21-3\t1\t+"),
+        BED.Record("chr21\t8445578\t8445731\tchr21-1\t1\t+"),
+        BED.Record("chr21\t8218308\t8218461\tchr21-2\t1\t+"),
+    ]
+
     #=
     Testing strategy: there are two entirely separate intersection algorithms for IntervalCollection and IntervalStream.
     Here we test them both by checking that they agree by generating and intersecting random BED files.


### PR DESCRIPTION
This PR:
- adds references to the BEDv1 specification to the documentation.
- adds comment and blank lines to the state machine.

Closes #13.