### PR TITLE
Migrate to Automa v1

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -6,40 +6,49 @@ on:
 
 jobs:
   test:
-    name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ matrix.julia-arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.0' # LTS
           - '1'
-        julia-arch: [x64, x86]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-        exclude:
-          - os: macOS-latest
-            julia-arch: x86
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         experimental: [false]
         include:
+          # Include nightly, but experimental, so it's allowed to fail without
+          # failing CI.
           - julia-version: nightly
-            julia-arch: x64
             os: ubuntu-latest
             experimental: true
+            fail_ci_if_error: false
+          # Windows is extremely slow on 1.6, so we skip this combination,
+          # since it increases CI time by 5x
+          - julia-version: '1.7'
+            os: windows-latest
+            experimental: false
+          # Oldest supported version
+          - julia-version: '1.6'
+            os: ubuntu-latest
+            experimental: false
+          # MacOS Aarch64 reached Tier1 support of Julia in version 1.9
+          - julia-version: '1.9'
+            os: macOS-latest
+            experimental: false
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Julia
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
       - name: Run Tests
-        uses: julia-actions/julia-runtest@v1
+        uses: julia-actions/julia-runtest@latest
       - name: Create CodeCov
-        uses: julia-actions/julia-processcoverage@v1
+        uses: julia-actions/julia-processcoverage@latest
       - name: Upload CodeCov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           file: ./lcov.info
           flags: unittests

--- a/Project.toml
+++ b/Project.toml
@@ -21,8 +21,8 @@ ColorTypes = "0.7, 0.8, 0.9, 0.10, 0.11"
 FixedPointNumbers = "0.5, 0.6, 0.7, 0.8"
 GenomicFeatures = "2"
 Indexes = "0.1"
-TranscodingStreams = "0.9.5"
-julia = "1"
+TranscodingStreams = "0.9.5, 0.10, 0.11"
+julia = "1.6"
 
 [extras]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Indexes = "4ffb77ac-cb80-11e8-1b35-4b78cc642f6d"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
-Automa = "0.7, 0.8"
+Automa = "1"
 BGZFStreams = "0.3"
 BioGenerics = "0.1"
 ColorTypes = "0.7, 0.8, 0.9, 0.10, 0.11"

--- a/src/BED.jl
+++ b/src/BED.jl
@@ -1,7 +1,7 @@
 module BED
 
-import Automa
-import Automa.RegExp: @re_str
+using Automa: Automa, @re_str, @mark, @markpos, @relpos, @abspos
+using Automa: onenter!, onexit!
 import BGZFStreams
 import BioGenerics
 import ColorTypes


### PR DESCRIPTION
This change is not entirely straightforward. One of the major changes in Automa v1 is the detection of ambiguos NFAs at compile time. Automa's behaviour in the presence of such NFAs is undefined.
It turns out that the existing BED Machines were ambiguous, which means there probably was some latent bugs waiting to happen.
To mitigate these, the Machine's behaviour has been slightly changed. In particular:
* Chrom now cannot start with # or with whitespace, to distinguish them from comments and whitespace
* Blank lines now no longer can start with tabs, to distinguish them from a record with an empty chrom name

I'm guessing this will not cause any issues in practise.

Supersedes #18, cc. @kescobo 